### PR TITLE
BSREM notebook improvements

### DIFF
--- a/src/notebooks/BSREM_illustration.ipynb
+++ b/src/notebooks/BSREM_illustration.ipynb
@@ -7,8 +7,13 @@
    "source": [
     "# Demonstration of basic BSREM implementation with SIRF\n",
     "\n",
-    "This notebook is largely based on the `display_and_projection` notebook from the SIRF-Exercises to simulate some data.\n",
-    "Then it proceeds with reconstructing it with BSREM."
+    "`BSREM1` and `BSREM2` are 2 different implementations of a (modified) BSREM algorithm. `BSREM1` uses the `sirf.STIR` objective function to compute gradients etc, while `BSREM2` computes these in terms of the `sirf.STIR.AcquisitionModel`. The actual algorithm is implemented in the base class `BSREMSkeleton`. Note that the implementations are in terms of \"lists of subset-data\" and corresponding \"list of acquisition models\" etc. (This is more efficient than using the subset functionality in the `sirf.STIR` acquisition models/objective function.)\n",
+    "\n",
+    "The source code for these implementations can be found in `src/Python`, or you could run `BSREM1??`\n",
+    "\n",
+    "This notebook is illustrates these algorithms with two datasets:\n",
+    "- a simple 2D simulation (largely based on the `display_and_projection` notebook from the SIRF-Exercises)\n",
+    "- the mMR NEMA IQ data (downloadable via the SIRF-exercises as well)"
    ]
   },
   {
@@ -70,7 +75,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23ed73ab-18a4-4a2d-8e01-ed5ecbc49690",
+   "id": "5",
    "metadata": {},
    "source": [
     "Import functionality from the Python files in SIRF-Contribs.\n",
@@ -80,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,18 +119,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# fewer message from STIR and SIRF\n",
+    "# fewer message from STIR and SIRF (set to higher value if you have problems)\n",
     "STIR.set_verbosity(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "# Some function definitions"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,23 +151,156 @@
     "        plt.clim(clims)\n",
     "    plt.colorbar(shrink=.4)\n",
     "    plt.title(title)\n",
-    "    plt.axis(\"off\")\n",
+    "    plt.axis(\"off\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_acq_model_and_obj_fun(acquired_data, additive_term, mult_factor, template_image):\n",
+    "    '''\n",
+    "    Create an acquisition model and objective function, corresponding to the given data.\n",
+    "    '''\n",
+    "    # We could construct this by hand here, but instead will just use `partitioner.data_partition`\n",
+    "    # with 1 subset, which will then do the work for us.\n",
+    "    num_subsets = 1\n",
+    "    _, acq_models, obj_funs = partitioner.data_partition(acquired_data, additive_term, mult_factors, num_subsets, initial_image=template_image)\n",
+    "    return (acq_models[0], obj_funs[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def scale_initial_image(acquired_data, additive_term, mult_factor, template_image, obj_fun):\n",
+    "    '''\n",
+    "    Return a uniform image that has a reasonable \"scale\" (i.e. image values) for the data given.\n",
+    "    \n",
+    "    If there is an additive term, OSEM can be a bit slow to converge if the initial image has very wrong\n",
+    "    image values. Here we find a scale such that the sum of the forward projection of the initial image is equal to the sum of the acquired data.\n",
+    "    \n",
+    "    WARNING: assumes that obj_fun has been set_up already\n",
+    "    '''\n",
+    "    data_sum = (acquired_data.sum() - (additive_term * mult_factors).sum())\n",
+    "    ratio = data_sum / (obj_fun.get_subset_sensitivity(0).sum() * obj_fun.get_num_subsets())\n",
+    "    return template_image.allocate(ratio)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def OSEM(obj_fun, initial_image, num_updates = 14, num_subsets = 2):\n",
+    "    '''\n",
+    "    run OSEM\n",
+    "    \n",
+    "    WARNING: this modified the `obj_fun` by setting its number of subsets. This is unfortunate of course.\n",
+    "    '''\n",
+    "    recon = STIR.OSMAPOSLReconstructor()\n",
+    "    recon.set_objective_function(obj_fun)\n",
+    "    recon.set_current_estimate(initial_image)\n",
+    "    recon.set_num_subsets(num_subsets )\n",
+    "    recon.set_num_subiterations(num_updates)\n",
+    "    recon.set_up(initial_image)\n",
+    "    recon.process()\n",
+    "    return recon.get_output()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def construct_RDP(penalty_strength, initial_image, kappa, max_scaling=1e-3):\n",
+    "    '''\n",
+    "    Construct a smoothed Relative Difference Prior (RDP)\n",
+    "    \n",
+    "    `initial_image` is used to determine a smoothing factor (epsilon).\n",
+    "    `kappa` is used to pass voxel-dependent weights.\n",
+    "    '''\n",
+    "    prior = STIR.RelativeDifferencePrior()\n",
+    "    # need to make it differentiable\n",
+    "    epsilon = initial_image.max() * max_scaling\n",
+    "    prior.set_epsilon(epsilon)\n",
+    "    prior.set_penalisation_factor(penalty_strength)\n",
+    "    prior.set_kappa(kappa)\n",
+    "    prior.set_up(initial_image)\n",
+    "    return prior"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_kappa_image(obj_fun, initial_image):\n",
+    "    '''\n",
+    "    Computes a \"kappa\" image for a prior as sqrt(H.1). This will attempt to give uniform \"perturbation response\".\n",
+    "    See Yu-jung Tsai et al. TMI 2020 https://doi.org/10.1109/TMI.2019.2913889\n",
     "\n",
-    "FOV_filter=STIR.TruncateToCylinderProcessor()"
+    "    WARNING: Assumes the objective function has been set-up already\n",
+    "    '''\n",
+    "    # This needs SIRF 3.7. If you don't have that yet, you should probably upgrade anyway!\n",
+    "    Hessian_row_sum = obj_fun.multiply_with_Hessian(initial_image, initial_image.allocate(1))\n",
+    "    return (-1*Hessian_row_sum).power(.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_prior_to_obj_funs(obj_funs, prior):\n",
+    "    '''\n",
+    "    Add prior evenly to every objective function in the obj_funs list.\n",
+    "    \n",
+    "    WARNING: modifies prior strength with 1/num_subsets (as currently needed for BSREM implementations)\n",
+    "    WARNING: modifies elements of obj_funs\n",
+    "    '''   \n",
+    "    # evenly distribute prior over subsets\n",
+    "    prior.set_penalisation_factor(prior.get_penalisation_factor() / len(obj_funs));\n",
+    "    prior.set_up(initial_image)\n",
+    "    for f in obj_funs:\n",
+    "        f.set_prior(prior)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Try it with the thorax_single_slice data"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "### First simulate some data\n",
+    "(see the SIRF-exercises for more info, e.g. https://github.com/SyneRBI/SIRF-Exercises/blob/master/notebooks/PET/display_and_projection.ipynb)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,18 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#%% save max for future displays\n",
-    "cmax = image.max()*.6"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +347,7 @@
     "# create acquisition model\n",
     "acq_model = STIR.AcquisitionModelUsingRayTracingMatrix()\n",
     "# we will increase the number of rays used for every Line-of-Response (LOR) as an example\n",
-    "# (it is not required for the exercise of course)\n",
+    "# (it is not required for this demo of course)\n",
     "acq_model.set_num_tangential_LORs(5)\n",
     "acq_model.set_acquisition_sensitivity(asm_attn)\n",
     "acq_model.set_additive_term(additive_term)\n",
@@ -226,131 +361,23 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "initial_image=image.get_uniform_copy(cmax / 4)\n",
-    "FOV_filter.apply(initial_image)\n",
-    "# display\n",
-    "im_slice = initial_image.dimensions()[0] // 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def initial_OSEM(acquired_data, additive_term, mult_factors, initial_image):\n",
-    "    num_subsets = 1\n",
-    "    data,acq_models, obj_funs = partitioner.data_partition(acquired_data, additive_term, mult_factors, num_subsets)\n",
-    "\n",
-    "    obj_fun = STIR.make_Poisson_loglikelihood(data[0])\n",
-    "    obj_fun.set_acquisition_model(acq_models[0])\n",
-    "    recon = STIR.OSMAPOSLReconstructor()\n",
-    "    recon.set_objective_function(obj_fun)\n",
-    "    recon.set_current_estimate(initial_image)\n",
-    "    # some arbitrary numbers here\n",
-    "    recon.set_num_subsets(2)\n",
-    "    num_subiters = 14\n",
-    "    recon.set_num_subiterations(num_subiters)\n",
-    "    recon.set_up(initial_image)\n",
-    "    recon.process()\n",
-    "    return recon.get_output()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    " OSEM_image = initial_OSEM(acquired_data, additive_term, mult_factors, initial_image)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "18",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.figure()\n",
-    "plot_2d_image([1,1,1], OSEM_image.as_array()[im_slice,:,:], 'OSEM',[0,cmax])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "19",
-   "metadata": {},
-   "source": [
-    "### partition data and construct prior"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "num_subsets = 7\n",
-    "data,acq_models, obj_funs = partitioner.data_partition(acquired_data,additive_term,mult_factors, num_subsets)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "21",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def add_RDP(beta, epsilon, obj_funs):\n",
-    "    '''\n",
-    "    construct RDP prior and add it evenly to every objective function.\n",
-    "    \n",
-    "    WARNING: return prior with beta/num_subsets (as currently needed for BSREM implementations)\n",
-    "    '''\n",
-    "    prior = STIR.RelativeDifferencePrior()\n",
-    "    # need to make it differentiable\n",
-    "    prior.set_epsilon(epsilon)\n",
-    "    # evenly distribute prior over subsets\n",
-    "    prior.set_penalisation_factor(beta / len(obj_funs));\n",
-    "    prior.set_up(initial_image)\n",
-    "    for f in obj_funs:\n",
-    "        f.set_prior(prior)\n",
-    "    return prior"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prior = add_RDP(1, initial_image.max()*1e-4, obj_funs)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "23",
    "metadata": {},
    "source": [
-    "### compare 2 BSREM implementations"
+    "### run initial OSEM"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "24",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "Note: intentionally setting update_objective_intervals to be not a multiple of num_subsets such that we can see the oscillations"
+    "#%% save max and central slice for future displays\n",
+    "cmax = image.max()*.6\n",
+    "im_slice = image.dimensions()[0] // 2"
    ]
   },
   {
@@ -360,9 +387,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bsrem1 = BSREM1(data, obj_funs, initial=OSEM_image, initial_step_size=1, relaxation_eta=.05, update_objective_interval=5)\n",
-    "bsrem1.max_iteration=300\n",
-    "bsrem1.run()"
+    "initial_image = image.get_uniform_copy()"
    ]
   },
   {
@@ -372,15 +397,183 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bsrem2=BSREM2(data, acq_models, prior, initial=OSEM_image, initial_step_size=1, relaxation_eta=.05, update_objective_interval=5)\n",
-    "bsrem2.max_iteration = bsrem1.max_iteration\n",
-    "bsrem2.run()"
+    "acq_model, obj_fun = create_acq_model_and_obj_fun(acquired_data, additive_term, mult_factors, initial_image)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "initial_image = scale_initial_image(acquired_data, additive_term, mult_factors, initial_image, obj_fun)\n",
+    "OSEM_image = OSEM(obj_fun, initial_image, num_updates=30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plot_2d_image([1,1,1], OSEM_image.as_array()[im_slice,:,:], 'OSEM',[0,cmax])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {},
+   "source": [
+    "### Construct the prior\n",
+    "\n",
+    "We will use a smoothed RDP with voxel-dependent weights (see function definitions above)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kappa = compute_kappa_image(obj_fun, OSEM_image)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plot_2d_image([1,1,1], kappa.as_array()[im_slice,:,:], 'kappa')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prior = construct_RDP(1/36, OSEM_image, kappa)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33",
+   "metadata": {},
+   "source": [
+    "### partition data (i.e. construct subsets) and adjust prior accordingly\n",
+    "\n",
+    "Use `partitioner.data_partition` to get a list of subset data, as well as corresponding acquisition models and objective functions. We'll add the prior evenly to each objective function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_subsets = 7\n",
+    "data,acq_models, obj_funs = partitioner.data_partition(acquired_data,additive_term,mult_factors, num_subsets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35",
+   "metadata": {},
+   "source": [
+    "add_prior_to_obj_funs(obj_funs, prior)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36",
+   "metadata": {},
+   "source": [
+    "Remember that this modified the penalty strength of the `prior` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prior.get_penalisation_factor()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38",
+   "metadata": {},
+   "source": [
+    "### compare 2 BSREM implementations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39",
+   "metadata": {},
+   "source": [
+    "`BSREM1` etc are derived from `cil.Algorithm`, Check its help message for more information.\n",
+    "\n",
+    "Some notes on terminology:\n",
+    "- CIL uses `loss` for the objective function value. This is somewhat confusing here, as we are maximising the objective function...\n",
+    "- `cil.Algorithm` uses `iteration` for every call to `update`. This might not be what you expect for a subset algorithm."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40",
+   "metadata": {},
+   "source": [
+    "Note: intentionally setting update_objective_intervals to be not a multiple of num_subsets such that we can see the oscillations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_iteration = 300"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bsrem1 = BSREM1(data, obj_funs, initial=OSEM_image, initial_step_size=1, relaxation_eta=.05, update_objective_interval=5)\n",
+    "bsrem1.run(iterations=max_iteration)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bsrem2=BSREM2(data, acq_models, prior, initial=OSEM_image, initial_step_size=1, relaxation_eta=.05, update_objective_interval=5)\n",
+    "bsrem2.run(iterations=max_iteration)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +586,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "45",
    "metadata": {},
    "source": [
     "Plot objective function for both implementations. If all well, you should see only 1 curve"
@@ -402,7 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,7 +616,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "48",
    "metadata": {},
    "source": [
     "## Now use the NEMA IQ data acquired on the mMR"
@@ -431,7 +624,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "49",
    "metadata": {},
    "source": [
     "The following names assume the data for the acquisition model has been written already by a preprocessing script. You might need to adjust this to your location and set-up."
@@ -440,7 +633,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,25 +643,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
     "acquired_data = STIR.AcquisitionData('prompts.hs')\n",
     "additive_term = STIR.AcquisitionData('additive_term.hs')\n",
-    "mult_factors = STIR.AcquisitionData('mult_factors.hs')\n",
-    "\n",
-    "# somewhat crazy initialisation, currently hand-tuned scale\n",
-    "initial_image = STIR.ImageData('20170809_NEMA_MUMAP_UCL.hv')+.5"
+    "mult_factors = STIR.AcquisitionData('mult_factors.hs')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Let's use the attenuation image to get descent voxel-sizes etc\n",
+    "# you might get a lot of warnings on \"unrecognized keyword\". Just ignore these...\n",
+    "initial_image = STIR.ImageData('20170809_NEMA_MUMAP_UCL.hv')\n",
     "# crop it a bit to avoid wasting time\n",
     "initial_image=initial_image.zoom_image(zooms=(1,1,1), offsets_in_mm=(0,0,0), size=(-1,200,200))"
    ]
@@ -476,29 +669,67 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# hand-tuned cmax (TODO fix)\n",
-    "cmax = .15\n",
-    "im_slice = 70"
+    "# run OSEM (see previous example) and construct kappa etc\n",
+    "acq_model, obj_fun = create_acq_model_and_obj_fun(acquired_data, additive_term, mult_factors, initial_image)\n",
+    "\n",
+    "initial_image = scale_initial_image(acquired_data, additive_term, mult_factors, initial_image, obj_fun)\n",
+    "OSEM_image = OSEM(obj_fun, initial_image, num_updates=14)\n",
+    "\n",
+    "kappa = compute_kappa_image(obj_fun, OSEM_image)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
-    "OSEM_image = initial_OSEM(acquired_data, additive_term, mult_factors, initial_image)"
+    "# set to reasonable values for display\n",
+    "cmax = OSEM_image.max()*1.1\n",
+    "im_slice = 70 # for this acquisition, this might give a slcie through the spheres"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plot_2d_image([1,1,1], OSEM_image.as_array()[im_slice,:,:], 'OSEM',[0, OSEM_image.max()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plot_2d_image([1,1,1], kappa.as_array()[im_slice,:,:], 'kappa')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prior = construct_RDP(1/700, OSEM_image, kappa)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,19 +741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# need to truncate max because of spurious high values at the edge of FOV\n",
-    "# TODO fix\n",
-    "OSEM_image = OSEM_image.minimum(.3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,29 +752,40 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
-    "prior = add_RDP(5, initial_image.max()*1e-4, obj_funs)"
+    "add_prior_to_obj_funs(obj_funs, prior)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
-    "bsrem1 = BSREM1(data, obj_funs, initial=OSEM_image, initial_step_size=1, relaxation_eta=.05, update_objective_interval=10)\n",
-    "bsrem1.max_iteration=80\n",
-    "bsrem1.run()"
+    "bsrem1 = BSREM1(data, obj_funs, initial=OSEM_image, initial_step_size=.3, relaxation_eta=.05, update_objective_interval=10)\n",
+    "bsrem1.run(iterations=80)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(bsrem1.x.max())\n",
+    "plt.figure()\n",
+    "plot_2d_image([1,2,2], bsrem1.x.as_array()[im_slice,:,:], 'BSREM',[0, bsrem1.x.max()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -567,7 +797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,18 +818,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython"
+    "name": "ipython",
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 improve BSREM example

- avoid difficulties with initial_image scale for OSEM
- add kappa image for prior as illustration
- define functions upfront
- add a bit more information on what's happening

This seems to all work fine. However, the overall penalty strength is still hand-tuned.